### PR TITLE
[Spring 43] Simple Word counter using only available Spring XD components

### DIFF
--- a/payload-value-counter/README.md
+++ b/payload-value-counter/README.md
@@ -1,0 +1,73 @@
+Payload Value Counter Demo
+==========================
+
+In this example you will learn how to create a simple custom counter with Spring XD.
+
+This counter is a variation of Spring XD's [field value counter](https://github.com/spring-projects/spring-xd/wiki/Analytics#field-value-counter). Unlike the original, it is not a field of the payload that sets the updated value, but the payload itself.
+
+We will use a simple example to illustrate how it works.
+
+Prerequisites
+-------------
+
+In order to get started, make sure that Spring XD is installed. You can find the instructions
+([here](https://github.com/spring-projects/spring-xd/wiki/Getting-Started)).
+
+## Building
+
+	$ mvn package
+
+## Using the Custom Module
+
+The uber-jar will be in `target/payload-value-counter-1.0.0.BUILD-SNAPSHOT.jar`. To install and register the module to your Spring XD distribution, use the `module upload` Spring XD shell command. Start Spring XD and the shell:
+
+```
+ _____                           __   _______
+/  ___|          (-)             \ \ / /  _  \
+\ `--. _ __  _ __ _ _ __   __ _   \ V /| | | |
+`--. \ '_ \| '__| | '_ \ / _` |  / ^ \| | | |
+/\__/ / |_) | |  | | | | | (_| | / / \ \ |/ /
+\____/| .__/|_|  |_|_| |_|\__, | \/   \/___/
+      | |                  __/ |
+      |_|                 |___/
+eXtreme Data
+1.1.0.BUILD-SNAPSHOT | Admin Server Target: http://localhost:9393
+Welcome to the Spring XD shell. For assistance hit TAB or type "help".
+xd:>module upload --file [path-to]/spring-xd-samples/payload-value-counter/target/payload-value-counter-1.0.0.BUILD-SNAPSHOT.jar --name payload-value-counter --type sink
+Successfully uploaded module 'sink:payload-value-counter'
+xd:>
+```
+
+Standalone mode
+---------------
+
+Start Spring XD in standalone mode.
+
+First, we create a normal ingestion stream, with the following modules:
+
+* a file source that monitors a directory containing text files - whenever a new file is copied there,
+the source will read it, each of the messages that it produces containing one line;
+* a splitter that receives the lines of text produced by the source, and splits them into words, using
+space as a separator (you can change the SpEL expression for more accuracy);
+* a sink that logs the emitted words.
+
+```
+stream create words --definition "file --dir=<directory-with-text-files> --outputType=text/plain | splitter --expression=payload.split(' ')  | log
+```
+
+Then we will tap the original stream and create a new one, for counting the words. We will use a field value counter for accumulating results in the
+* the `words` stream is tapped after the splitter;
+* we use a transformer to wrap the individual words into Spring XD `Tuple`s, which are one of the expected inputs for the field value counter.
+
+
+```
+stream create wordcount --definition "tap:stream:words.splitter > payload-value-counter"
+```
+
+You can use the [analytics-dashboard](../analytics-dashboard) project to visualize the word counts as the stream is processed.
+
+Distributed mode
+----------------
+
+In a distributed mode, the scenario is identical, except the module counts can be adjusted.
+

--- a/payload-value-counter/pom.xml
+++ b/payload-value-counter/pom.xml
@@ -1,0 +1,62 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>com.acme</groupId>
+	<artifactId>payload-value-counter</artifactId>
+	<version>1.0.0.BUILD-SNAPSHOT</version>
+	<parent>
+		<groupId>org.springframework.xd</groupId>
+		<artifactId>spring-xd-module-parent</artifactId>
+		<version>1.1.0.RELEASE</version>
+	</parent>
+
+	<repositories>
+		<repository>
+			<id>spring-releases</id>
+			<name>Spring Releases</name>
+			<url>http://repo.spring.io/release</url>
+			<snapshots>
+				<enabled>false</enabled>
+			</snapshots>
+		</repository>
+		<repository>
+			<id>spring-milestones</id>
+			<name>Spring Milestones</name>
+			<url>http://repo.spring.io/libs-milestone</url>
+			<snapshots>
+				<enabled>false</enabled>
+			</snapshots>
+		</repository>
+	</repositories>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.xd</groupId>
+			<artifactId>spring-xd-analytics</artifactId>
+			<version>${spring.xd.version}</version>
+			<scope>provided</scope>
+			<exclusions>
+				<exclusion>
+					<artifactId>spring-xd-hadoop</artifactId>
+					<groupId>org.springframework.xd</groupId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+	</dependencies>
+
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.2</version>
+				<configuration>
+					<source>1.8</source>
+					<target>1.8</target>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/payload-value-counter/src/main/java/com/acme/PayloadValueCounterHandler.java
+++ b/payload-value-counter/src/main/java/com/acme/PayloadValueCounterHandler.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.acme;
+
+
+import org.springframework.integration.annotation.ServiceActivator;
+import org.springframework.messaging.Message;
+import org.springframework.util.Assert;
+import org.springframework.xd.analytics.metrics.core.FieldValueCounterRepository;
+
+/**
+ * @author Marius Bogoevici
+ */
+public class PayloadValueCounterHandler {
+
+	private String name;
+
+	private FieldValueCounterRepository fieldValueCounterRepository;
+
+	public PayloadValueCounterHandler(FieldValueCounterRepository fieldValueCounterRepository, String name) {
+		Assert.hasText(name, "must have a name");
+		Assert.notNull(fieldValueCounterRepository, "cannot be null");
+		this.name = name;
+		this.fieldValueCounterRepository = fieldValueCounterRepository;
+	}
+
+	@ServiceActivator
+	public void handleMessage(Message<?> message) throws Exception {
+		if (message.getPayload() != null) {
+			fieldValueCounterRepository.increment(name, message.getPayload().toString());
+		}
+	}
+}

--- a/payload-value-counter/src/main/java/com/acme/PayloadValueCounterHandlerOptions.java
+++ b/payload-value-counter/src/main/java/com/acme/PayloadValueCounterHandlerOptions.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.acme;
+
+import static org.springframework.xd.module.options.spi.ModulePlaceholders.XD_STREAM_NAME;
+
+import org.springframework.xd.module.options.spi.ModuleOption;
+import org.springframework.xd.module.options.spi.ModulePlaceholders;
+
+/**
+ * @author Marius Bogoevici
+ */
+public class PayloadValueCounterHandlerOptions {
+
+	private String name = ModulePlaceholders.XD_STREAM_NAME;
+
+	public String getName() {
+		return name;
+	}
+
+	@ModuleOption(value = "the name of the metric to contribute to (will be created if necessary)", defaultValue = XD_STREAM_NAME)
+	public void setName(String name) {
+		this.name = name;
+	}
+}

--- a/payload-value-counter/src/main/resources/config/payload-value-counter.xml
+++ b/payload-value-counter/src/main/resources/config/payload-value-counter.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:int="http://www.springframework.org/schema/integration"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd">
+
+	<int:channel id="input"/>
+
+	<int:service-activator input-channel="input" ref="handler" output-channel="nullChannel"/>
+
+	<bean id="handler" class="com.acme.PayloadValueCounterHandler">
+		<constructor-arg ref="fieldValueCounterRepository"/>
+		<constructor-arg value="${name}"/>
+	</bean>
+
+</beans>

--- a/payload-value-counter/src/main/resources/config/spring-module.properties
+++ b/payload-value-counter/src/main/resources/config/spring-module.properties
@@ -1,0 +1,1 @@
+options_class = com.acme.PayloadValueCounterHandlerOptions

--- a/simple-word-count/README.md
+++ b/simple-word-count/README.md
@@ -1,0 +1,46 @@
+Simple Word Count Demo
+======================
+
+In this example you will learn how to create a simple word count application with Spring XD, 
+and you will do that without writing a single line of code, relying on the native capabilities 
+of Spring XD only. 
+
+Prerequisites
+-------------
+
+In order to get started, make sure that Spring XD is installed. You can find the instructions 
+([here](https://github.com/spring-projects/spring-xd/wiki/Getting-Started)).
+
+Standalone mode
+---------------
+
+Start Spring XD in standalone mode.
+
+First, we create a normal ingestion stream, with the following modules:
+
+* a file source that monitors a directory containing text files - whenever a new file is copied there,
+the source will read it, each of the messages that it produces containing one line;
+* a splitter that receives the lines of text produced by the source, and splits them into words, using
+space as a separator (you can change the SpEL expression for more accuracy);
+* a sink that logs the emitted words.  
+
+```
+stream create words --definition "file --dir=<directory-with-text-files> --outputType=text/plain | splitter --expression=payload.split(' ')  | log
+```
+
+Then we will tap the original stream and create a new one, for counting the words. We will use a field value counter for accumulating results in the 
+* the `words` stream is tapped after the splitter;
+* we use a transformer to wrap the individual words into Spring XD `Tuple`s, which are one of the expected 
+
+
+```
+stream create wordcount --definition "tap:stream:words.transformer > transform --expression=T(org.springframework.xd.tuple.TupleBuilder).tuple().of('word',payload) | field-value-counter --fieldName=word"
+```
+
+You can use the [analytics-dashboard]() project to visualize the word counts as the stream is processed.
+
+Distributed mode
+----------------
+
+In a distributed mode, the scenario is identical, except the module counts can be adjusted.
+

--- a/simple-word-count/README.md
+++ b/simple-word-count/README.md
@@ -30,11 +30,11 @@ stream create words --definition "file --dir=<directory-with-text-files> --outpu
 
 Then we will tap the original stream and create a new one, for counting the words. We will use a field value counter for accumulating results in the 
 * the `words` stream is tapped after the splitter;
-* we use a transformer to wrap the individual words into Spring XD `Tuple`s, which are one of the expected 
+* we use a transformer to wrap the individual words into Spring XD `Tuple`s, which are one of the expected inputs for the field value counter.
 
 
 ```
-stream create wordcount --definition "tap:stream:words.transformer > transform --expression=T(org.springframework.xd.tuple.TupleBuilder).tuple().of('word',payload) | field-value-counter --fieldName=word"
+stream create wordcount --definition "tap:stream:words.splitter > transform --expression=T(org.springframework.xd.tuple.TupleBuilder).tuple().of('word',payload) | field-value-counter --fieldName=word"
 ```
 
 You can use the [analytics-dashboard]() project to visualize the word counts as the stream is processed.


### PR DESCRIPTION
- file reading is handled by a file source (which natively splits content by line)
- word splitting is handled by a splitter
- word counting is done by a field value counter
- visualization through the analytics-dashboard
- variant using a custom counter, for a simpler stream structure