### PR TITLE
URL Cleanup

### DIFF
--- a/sample-modules-parent/build.gradle
+++ b/sample-modules-parent/build.gradle
@@ -17,9 +17,9 @@ group = 'org.springframework.xd.samples'
 version = '1.0.0.BUILD-SNAPSHOT'
 
 repositories {
-    maven { url "http://repo.spring.io/release" }
+    maven { url "https://repo.spring.io/release" }
     mavenCentral()
     jcenter()
-    maven { url "http://repo.spring.io/snapshot" }
-    maven { url "http://repo.spring.io/milestone" }
+    maven { url "https://repo.spring.io/snapshot" }
+    maven { url "https://repo.spring.io/milestone" }
 }

--- a/sample-modules-parent/buildscript.gradle
+++ b/sample-modules-parent/buildscript.gradle
@@ -1,10 +1,10 @@
 
     repositories {
-        maven { url "http://repo.spring.io/plugins-snapshot" }
-        maven { url 'http://repo.spring.io/plugins-release' }
-        maven { url "http://repo.spring.io/release" }
-        maven { url "http://repo.spring.io/milestone" }
-        maven { url "http://repo.spring.io/snapshot" }
+        maven { url "https://repo.spring.io/plugins-snapshot" }
+        maven { url 'https://repo.spring.io/plugins-release' }
+        maven { url "https://repo.spring.io/release" }
+        maven { url "https://repo.spring.io/milestone" }
+        maven { url "https://repo.spring.io/snapshot" }
         jcenter()
     }
     dependencies {

--- a/sample-modules-parent/pom.xml
+++ b/sample-modules-parent/pom.xml
@@ -18,12 +18,12 @@
 	<repositories>
 		<repository>
 			<id>jcenter</id>
-			<url>http://jcenter.bintray.com</url>
+			<url>https://jcenter.bintray.com</url>
 		</repository>
 		<repository>
 			<id>spring-milestones</id>
 			<name>Spring Milestones</name>
-			<url>http://repo.spring.io/milestone</url>
+			<url>https://repo.spring.io/milestone</url>
 			<snapshots>
 				<enabled>false</enabled>
 			</snapshots>
@@ -31,7 +31,7 @@
 		<repository>
 			<id>spring-release</id>
 			<name>Spring Releases</name>
-			<url>http://repo.spring.io/libs-release</url>
+			<url>https://repo.spring.io/libs-release</url>
 			<snapshots>
 				<enabled>false</enabled>
 			</snapshots>
@@ -39,7 +39,7 @@
 		<repository>
 			<id>spring-snapshots</id>
 			<name>Spring Snapshots</name>
-			<url>http://repo.spring.io/snapshot</url>
+			<url>https://repo.spring.io/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/samples-parent/pom.xml
+++ b/samples-parent/pom.xml
@@ -38,12 +38,12 @@
 	<repositories>
 		<repository>
 			<id>jcenter</id>
-			<url>http://jcenter.bintray.com</url>
+			<url>https://jcenter.bintray.com</url>
 		</repository>
 		<repository>
 			<id>spring-milestones</id>
 			<name>Spring Milestones</name>
-			<url>http://repo.spring.io/milestone</url>
+			<url>https://repo.spring.io/milestone</url>
 			<snapshots>
 				<enabled>false</enabled>
 			</snapshots>
@@ -51,7 +51,7 @@
 		<repository>
 			<id>spring-release</id>
 			<name>Spring Releases</name>
-			<url>http://repo.spring.io/release</url>
+			<url>https://repo.spring.io/release</url>
 			<snapshots>
 				<enabled>false</enabled>
 			</snapshots>
@@ -59,7 +59,7 @@
 		<repository>
 			<id>spring-snapshots</id>
 			<name>Spring Snapshots</name>
-			<url>http://repo.spring.io/snapshot</url>
+			<url>https://repo.spring.io/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/smartgrid-prediction/frontend/pom.xml
+++ b/smartgrid-prediction/frontend/pom.xml
@@ -80,13 +80,13 @@
     <repositories>
         <repository>
             <id>spring-releases</id>
-            <url>http://repo.spring.io/libs-release</url>
+            <url>https://repo.spring.io/libs-release</url>
         </repository>
     </repositories>
     <pluginRepositories>
         <pluginRepository>
             <id>spring-releases</id>
-            <url>http://repo.spring.io/libs-release</url>
+            <url>https://repo.spring.io/libs-release</url>
         </pluginRepository>
     </pluginRepositories>
 

--- a/spark-streaming-logger-java-sink/build.gradle
+++ b/spark-streaming-logger-java-sink/build.gradle
@@ -14,7 +14,7 @@ configurations {
 
 repositories {
 	mavenCentral()
-	maven { url 'http://repo.spring.io/release' }	
+	maven { url 'https://repo.spring.io/release' }	
 }
 
 dependencies {

--- a/spark-streaming-logger-scala-sink/build.gradle
+++ b/spark-streaming-logger-scala-sink/build.gradle
@@ -17,7 +17,7 @@ configurations {
 
 repositories {
 	mavenCentral()
-	maven { url 'http://repo.spring.io/release' }	
+	maven { url 'https://repo.spring.io/release' }	
 }
 
 dependencies {

--- a/spark-streaming-wordcount-java-processor/build.gradle
+++ b/spark-streaming-wordcount-java-processor/build.gradle
@@ -14,7 +14,7 @@ configurations {
 
 repositories {
 	mavenCentral()
-	maven { url 'http://repo.spring.io/release' }	
+	maven { url 'https://repo.spring.io/release' }	
 }
 
 dependencies {

--- a/spark-streaming-wordcount-scala-processor/build.gradle
+++ b/spark-streaming-wordcount-scala-processor/build.gradle
@@ -17,7 +17,7 @@ configurations {
 
 repositories {
 	mavenCentral()
-	maven { url 'http://repo.spring.io/release' }	
+	maven { url 'https://repo.spring.io/release' }	
 }
 
 dependencies {

--- a/storm-product-analytics-example/redis-common/pom.xml
+++ b/storm-product-analytics-example/redis-common/pom.xml
@@ -22,11 +22,11 @@
 	<repositories>
 		<repository>
 			<id>spring-io-release</id>
-			<url>http://repo.spring.io/release</url>
+			<url>https://repo.spring.io/release</url>
 		</repository>
 		<repository>
 			<id>jcenter</id>
-			<url>http://jcenter.bintray.com</url>
+			<url>https://jcenter.bintray.com</url>
 		</repository>
 	</repositories>
 </project>

--- a/tweet-transformer-processor/build.gradle
+++ b/tweet-transformer-processor/build.gradle
@@ -40,10 +40,10 @@ task wrapper(type: Wrapper) {
 }
 
 repositories {
-	maven { url "http://repo.spring.io/release" }	
+	maven { url "https://repo.spring.io/release" }	
 	mavenCentral()
 	jcenter()
-	maven { url "http://repo.spring.io/snapshot" }
-	maven { url "http://repo.spring.io/milestone" }
+	maven { url "https://repo.spring.io/snapshot" }
+	maven { url "https://repo.spring.io/milestone" }
 }
 


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were fixed successfully.

* http://jcenter.bintray.com migrated to:  
  https://jcenter.bintray.com ([https](https://jcenter.bintray.com) result 200).
* http://repo.spring.io/libs-release migrated to:  
  https://repo.spring.io/libs-release ([https](https://repo.spring.io/libs-release) result 302).
* http://repo.spring.io/milestone migrated to:  
  https://repo.spring.io/milestone ([https](https://repo.spring.io/milestone) result 302).
* http://repo.spring.io/plugins-release migrated to:  
  https://repo.spring.io/plugins-release ([https](https://repo.spring.io/plugins-release) result 302).
* http://repo.spring.io/plugins-snapshot migrated to:  
  https://repo.spring.io/plugins-snapshot ([https](https://repo.spring.io/plugins-snapshot) result 302).
* http://repo.spring.io/release migrated to:  
  https://repo.spring.io/release ([https](https://repo.spring.io/release) result 302).
* http://repo.spring.io/snapshot migrated to:  
  https://repo.spring.io/snapshot ([https](https://repo.spring.io/snapshot) result 302).

# Ignored
These URLs were intentionally ignored.

* http://localhost:9393/modules/processor/analytic-pmml
* http://maven.apache.org/POM/4.0.0
* http://maven.apache.org/maven-v4_0_0.xsd
* http://maven.apache.org/xsd/maven-4.0.0.xsd
* http://www.w3.org/2001/XMLSchema-instance